### PR TITLE
Different callbacks for each alert

### DIFF
--- a/MessageBar.js
+++ b/MessageBar.js
@@ -205,8 +205,8 @@ class MessageBar extends Component {
     }
 
     // Execute the callback passed in parameter
-    if (this.props.onTapped) {
-      this.props.onTapped();
+    if (this.state.onTapped) {
+      this.state.onTapped();
     }
   }
 
@@ -215,8 +215,8 @@ class MessageBar extends Component {
   * Callback executed when alert is shown
   */
   _onShow() {
-    if (this.props.onShow) {
-      this.props.onShow();
+    if (this.state.onShow) {
+      this.state.onShow();
     }
   }
 
@@ -225,8 +225,8 @@ class MessageBar extends Component {
   * Callback executed when alert is hidden
   */
   _onHide() {
-    if (this.props.onHide) {
-      this.props.onHide();
+    if (this.state.onHide) {
+      this.state.onHide();
     }
   }
 


### PR DESCRIPTION
Currently, callbacks are read from props of the MessageBar component. This limits our ability to define a different callback for each alert. State is already updated with props passed via MessageBar.showAlert function so why not use state to call these callbacks instead of component props? This way we can define different callbacks for each alert.

This also makes it easier to deal with callbacks when you have a single MessageBar component below top level parent component and simply update it each time.
