### PR TITLE
Avatars can be local images too, not just URLs

### DIFF
--- a/MessageBar.js
+++ b/MessageBar.js
@@ -59,7 +59,7 @@ class MessageBar extends Component {
       /* Cusomisation of the alert: Title, Message, Icon URL, Alert alertType (error, success, warning, info), Duration for Alert keep shown */
       title: props.title,
       message: props.message,
-      avatarUrl: props.avatarUrl,
+      avatar: props.avatar,
       alertType: props.alertType || 'info',
       duration: props.duration || 3000,
 
@@ -376,9 +376,9 @@ class MessageBar extends Component {
   }
 
   renderImage() {
-    if (this.state.avatarUrl != null) {
+    if (this.state.avatar != null) {
       return (
-        <Image source={{ uri: this.state.avatarUrl }} style={this.state.avatarStyle} />
+        <Image source={this.state.avatar} style={this.state.avatarStyle} />
       );
     }
   }

--- a/MessageBar.js
+++ b/MessageBar.js
@@ -205,8 +205,8 @@ class MessageBar extends Component {
     }
 
     // Execute the callback passed in parameter
-    if (this.props.onTapped) {
-      this.props.onTapped();
+    if (this.state.onTapped) {
+      this.state.onTapped();
     }
   }
 
@@ -215,8 +215,8 @@ class MessageBar extends Component {
   * Callback executed when alert is shown
   */
   _onShow() {
-    if (this.props.onShow) {
-      this.props.onShow();
+    if (this.state.onShow) {
+      this.state.onShow();
     }
   }
 
@@ -225,8 +225,8 @@ class MessageBar extends Component {
   * Callback executed when alert is hidden
   */
   _onHide() {
-    if (this.props.onHide) {
-      this.props.onHide();
+    if (this.state.onHide) {
+      this.state.onHide();
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ MessageBarManager.showAlert({
 
   title: "John Doe", // Title of the alert
   message: "Hello, any suggestions?", // Message of the alert
-  avatarUrl: "<URL of your icon/avatar>", // Avatar/Icon URL of the alert
+  avatar: {uri: "<URL of your icon/avatar>"}, // Avatar/Icon URL of the alert or enter require('LOCALPATH') for local image
 
   /* Number of Lines for Title and Message */
   titleNumberOfLines: 1,
@@ -195,7 +195,7 @@ Prop                  | Type     | Default              | Description
 --------------------- | -------- | -------------------- | -----------
 title                 | String   |                      | Title of the alert
 message               | String   |                      | Message of the alert
-avatarUrl             | String   |                      | Avatar/Icon URL of the alert
+avatar                | String   |                      | Avatar/Icon source/URL of the alert
 alertType             | String   | info                 | Alert Type: you can select one of 'success', 'error', 'warning', 'error', or 'custom' (use custom if you use a 5th stylesheet, all are customizable).
 duration              | Number   | 3000                 | Number of ms the alert is displayed  
 shouldHideAfterDelay  | Bool     | true                 | Tell the MessageBar whether or not it should hide after a delay defined in the `duration` property. If `false`, the MessageBar remain shown


### PR DESCRIPTION
I think it’s better to leave the design flexible and let the user decide if they want to use local images or images online. This pull request changes the avatarUrl prop to avatar and allows for the ability to add local images.
to add local image:
`‘avatar’: require(‘../myImage.png’)`
to add online image:
`‘avatar’: {uri: ‘http://example.com/myImage.png’}`
