### PR TITLE
Require React from 'react' instead of 'react-native'

### DIFF
--- a/MessageBar.js
+++ b/MessageBar.js
@@ -5,9 +5,9 @@
  */
 'use strict';
 
-import React, {
+import React, { Component } from 'react'
+import {
   AppRegistry,
-  Component,
   StyleSheet,
   Text,
   View,


### PR DESCRIPTION
Deprecated in RN 25.

https://github.com/facebook/react-native/releases/tag/v0.25.1
